### PR TITLE
Support both versions of the vcsDate/vcsdate macro

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ meta.tex: Makefile .FORCE
 	printf '\\newcommand{\\lsstDocNum}{$(DOCNUMBER)}\n' >>$@
 	printf '\\newcommand{\\vcsRevision}{$(GITVERSION)$(GITDIRTY)}\n' >>$@
 	printf '\\newcommand{\\vcsDate}{$(GITDATE)}\n' >>$@
+	printf '\\newcommand{\\vcsdate}{$(GITDATE)}\n' >>$@
 
 
 generate: .FORCE

--- a/history_and_info.tex
+++ b/history_and_info.tex
@@ -5,4 +5,4 @@
 
 \setDocCurator{Gregory Dubois-Felsmann}
 \setDocUpstreamLocation{\url{https://github.com/lsst-dm/\lsstDocType-\lsstDocNum}}
-\setDocUpstreamVersion{\vcsrevision}
+\setDocUpstreamVersion{\vcsRevision}


### PR DESCRIPTION
This fixes a backward/forward compatibility problem with `docsteady`.